### PR TITLE
Increasing responsiveness

### DIFF
--- a/omodoro
+++ b/omodoro
@@ -15,9 +15,11 @@ from os.path import exists, join
 if version_info >= (3, 0):
     get_input = input
     from configparser import ConfigParser, NoOptionError
+    import queue
 else:
     get_input = raw_input
     from ConfigParser import ConfigParser, NoOptionError
+    import Queue as queue
 if platformname() == 'Windows':
     onWindows = True
 else:
@@ -70,6 +72,7 @@ time_left = None # time left after the pause
 state = States.Pomodori
 command = "" # input string
 lockObject = Lock()
+thread_signal = queue.Queue() # wake up the PomodoroThread when sleeping
 nextState = False # indicates user-triggered state change
 
 def changeState(newState, length):
@@ -156,8 +159,10 @@ class PomodoroThread(Thread):
                 print("Error - aborting.")
                 exit(1)
             lockObject.release()
-            sleep(30)
-        print("Shutdown finished.")
+            try:
+                thread_signal.get(block=True, timeout=30)
+            except queue.Empty:
+                pass
 
 
 if __name__ == "__main__":
@@ -226,7 +231,7 @@ if __name__ == "__main__":
             print("Continuing the current pomodoro cycle.\nNew End Time: %s\n$ " % end_time.strftime("%H:%M"), end="")
         elif command == "n":
             nextState = True
-            print("Skipping to next pomodori/break, please wait some seconds.", end="")
+            thread_signal.put(None)
         elif command == "s":
             if state == States.Pomodori:
                 print("Pomodoro cycle", end="")
@@ -246,7 +251,7 @@ if __name__ == "__main__":
                 lockObject.release()
             except ThreadError:
                 pass # Lock was not locked - exit anyway
-            print("omodoro is shutting down, please wait some seconds.")
+            thread_signal.put(None)
             exit(0)
         elif command == "t":
             if terminal_bell == True:

--- a/omodoro
+++ b/omodoro
@@ -212,53 +212,62 @@ if __name__ == "__main__":
 
     # commandline interface
     while True:
-        command = get_input()
-        if command == "p":
-            if time_left is None: # if not None, already paused
-                if lockObject.acquire(True):
-                    time_left = end_time - datetime.now()
-                    print("Paused.\n$ ", end="")
-            else:
-                print("Error: current cycle is already paused.\n$ ", end="")
-        elif command == "c":
-            try:
-                lockObject.release()
-            except ThreadError:
-                print("Error: current cycle is not paused.\n$ ", end="")
-                continue
-            end_time = datetime.now() + time_left
-            time_left = None
-            print("Continuing the current pomodoro cycle.\nNew End Time: %s\n$ " % end_time.strftime("%H:%M"), end="")
-        elif command == "n":
-            nextState = True
-            thread_signal.put(None)
-        elif command == "s":
-            if state == States.Pomodori:
-                print("Pomodoro cycle", end="")
-            elif state == States.ShortBreak:
-                print("Short break", end="")
-            elif state == States.LongBreak:
-                print("Long break", end="")
+        try:
+            command = get_input()
+            if command == "p":
+                if time_left is None: # if not None, already paused
+                    if lockObject.acquire(True):
+                        time_left = end_time - datetime.now()
+                        print("Paused.\n$ ", end="")
+                else:
+                    print("Error: current cycle is already paused.\n$ ", end="")
+            elif command == "c":
+                try:
+                    lockObject.release()
+                except ThreadError:
+                    print("Error: current cycle is not paused.\n$ ", end="")
+                    continue
+                end_time = datetime.now() + time_left
+                time_left = None
+                print("Continuing the current pomodoro cycle.\nNew End Time: %s\n$ " % end_time.strftime("%H:%M"), end="")
+            elif command == "n":
+                nextState = True
+                thread_signal.put(None)
+            elif command == "s":
+                if state == States.Pomodori:
+                    print("Pomodoro cycle", end="")
+                elif state == States.ShortBreak:
+                    print("Short break", end="")
+                elif state == States.LongBreak:
+                    print("Long break", end="")
 
-            if time_left is None:
-                print(", running, %d minutes left\n$ " % round(
-                    (end_time - datetime.now()).total_seconds() / 60) , end="")
+                if time_left is None:
+                    print(", running, %d minutes left\n$ " % round(
+                        (end_time - datetime.now()).total_seconds() / 60) , end="")
+                else:
+                    print(", paused, %d minutes left\n$ " % round(
+                        time_left.total_seconds() / 60), end="")
+            elif command == "q":
+                try:
+                    lockObject.release()
+                except ThreadError:
+                    pass # Lock was not locked - exit anyway
+                thread_signal.put(None)
+                exit(0)
+            elif command == "t":
+                if terminal_bell == True:
+                    terminal_bell = False
+                    print("Terminal bell off")
+                elif terminal_bell == False:
+                    terminal_bell = True
+                    print("Terminal bell on")
             else:
-                print(", paused, %d minutes left\n$ " % round(
-                    time_left.total_seconds() / 60), end="")
-        elif command == "q":
+                print("Unknown command.\n$ ", end="")
+        except KeyboardInterrupt:
+            command = "q" # indicate the PomodoroThread to quit
             try:
                 lockObject.release()
             except ThreadError:
                 pass # Lock was not locked - exit anyway
             thread_signal.put(None)
             exit(0)
-        elif command == "t":
-            if terminal_bell == True:
-                terminal_bell = False
-                print("Terminal bell off")
-            elif terminal_bell == False:
-                terminal_bell = True
-                print("Terminal bell on")
-        else:
-            print("Unknown command.\n$ ", end="")


### PR DESCRIPTION
This PR increases the responsiveness in two ways:

## Skipping and Quitting
Currently if 'n' or 'q' command is submitted, it takes up to 30 seconds for the program to respond.

This issue is resolved by introducing a signaling mechanism (queue) to wake up the thread on those events, such that the thread can immediately respond to those events.

## Quitting via Ctrl-c
Currently the program hangs when trying to kill it with Ctrl-c.

This issue is resolved by handling the KeyboardInterrupt exception and cleanly shutting down the program immediately.
